### PR TITLE
TEL-21198: In gossip, fix parseHostPort() to handle IPv6 addresses.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -508,7 +508,7 @@ func ParseSipUri(uriStr string) (uri base.SipUri, err error) {
 // The port may or may not be present, so we represent it with a *uint16,
 // and return 'nil' if no port was present.
 func parseHostPort(rawText string) (host string, port *uint16, err error) {
-	ipv6_re := regexp.MustCompile(`(\[[0-9a-zA-Z:.]+\])(:([0-9]+))*`)
+	ipv6_re := regexp.MustCompile(`(\[[0-9a-zA-Z:.]+\])(:([0-9]+))?`)
 	ipv6_matches := ipv6_re.FindStringSubmatch(rawText)
 	colonIdx := -1
 	// If rawText has an IPv4 address or an IPv6 address with port.

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -508,7 +508,7 @@ func ParseSipUri(uriStr string) (uri base.SipUri, err error) {
 // The port may or may not be present, so we represent it with a *uint16,
 // and return 'nil' if no port was present.
 func parseHostPort(rawText string) (host string, port *uint16, err error) {
-	ipv6_re := regexp.MustCompile(`(\[[0-9a-zA-Z:]+\])(:([0-9]+))*`)
+	ipv6_re := regexp.MustCompile(`(\[[0-9a-zA-Z:.]+\])(:([0-9]+))*`)
 	ipv6_matches := ipv6_re.FindStringSubmatch(rawText)
 	colonIdx := -1
 	// If rawText has an IPv4 address or an IPv6 address with port.


### PR DESCRIPTION
The gossip library's parseHostPort() function didn't support parsing IPv6 addresses without a :port_num suffix. (It that scenario, it would incorrectly assume that the colon for the IPv6 address is the port number delimiter).

This change fixes the function so that it can handle that case.

Testing:
- On a prober machine, use sipp to send a SIP INVITE message with a hardcoded SIP request URI with an IPv6 address but no port number, and make sure siplogger logs an error in /var/log/siplogger.log . You can, for example, use the fs_load_tests loadtest.py script to do so, by modifying the template XML, and then aiming the script at an IPv4 address of any BM machine.
- Recompile the siplogger executable with the modified gossip library. Overwrite the copy of /usr/local/siplogger/siplogger with the new version, and restart the siplogger service.
- Rerun the sipp test with the hardcoded SIP request URI (with an IPv6 address with no port number) and verify that /var/log/siplogger.log no longer logs any errors. Also, look up the SIP Call ID in the sipp_loadtest_*_messages.log file, and search for the SIP INVITE messages in the sipviewer, and confirm that the SIP INVITEs can now be seen in the SIP viewer.